### PR TITLE
Rebranding to LCI

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-computinged.uw.edu
+lci.uw.edu

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# computinged-uw.github.io
-The website for the ComputingEd@UW community
+# uw-lci.github.io
+The website for the LCI community

--- a/index.html
+++ b/index.html
@@ -583,6 +583,11 @@
 
           <table class="table table-striped">
             <tr>
+              <td><a href="https://stefania11.github.io">Stefania Druga</a></td>
+              <td>PhD student</td>
+              <td>iSchool</td>
+            </tr>
+            <tr>
               <td>
                 <a href="http://students.washington.edu/andrewhu/"
                   >Anne Drew Hu</a

--- a/index.html
+++ b/index.html
@@ -160,12 +160,12 @@
                  with more reading and more written work expected.
             </li>
             <li>
-              Join one of Amy's
+              Join one of Amy Ko's
               <a
                 href="http://faculty.washington.edu/ajko/lablets"
                 target="_blank"
                 >lablets</a
-              >, in the Code and Cognition Lab. These are informal research
+              >. These are informal research
               gatherings amongst students, led by Amy and her postdocs and
               doctoral students.
             </li>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
 
-    <title>ComputingEd @ UW</title>
+    <title>Center for Learning, Computing, and Imagination @ University of Washington</title>
 
     <link
       rel="stylesheet"
@@ -24,7 +24,7 @@
       <div class="row justify-content-center">
         <div class="col-sm-12 col-md-12 col-lg-9">
           <h1>
-            ComputingEd@<img
+            Learning, Computing, and Imagination@<img
               src="images/uwlogo.png"
               alt="The University of Washington block W logo."
               style="height: 0.8em; vertical-align: baseline"
@@ -32,9 +32,10 @@
           </h1>
 
           <p class="lead">
-            Welcome to ComputingEd@UW, a community of UW faculty and students
+            Welcome to the Center for Learning, Computing, and Imagination (LCI), 
+            a community of UW faculty and students
             passionate about 1) research about how people learn computing and 2)
-            the practice of how people teach computing.
+            the practice of teaching computing.
           </p>
 
           <p>Our community spans faculty and students from:</p>
@@ -152,6 +153,11 @@
               >. It's got a graduate level course number, but it's open to
               students at all levels. It often discusses computing education
               research papers and their application to CS teaching.
+            </li>
+            <li> Sign up for the <a href="https://benshapi.ro/courses/cse599cer/">
+                   CSE 599 Computing Education Research
+                 </a> course. It's like 590E, but primarily intended for PhD students, 
+                 with more reading and more written work expected.
             </li>
             <li>
               Join one of Amy's
@@ -502,7 +508,7 @@
               <td>CSE</td>
             </tr>
             <tr>
-              <td><a href="https://benshapi.ro/">R. Ben Shapiro</a></td>
+              <td><a href="https://benshapi.ro/">R. Benjamin Shapiro</a></td>
               <td>Associate Professor</td>
               <td>CSE</td>
             </tr>


### PR DESCRIPTION
This PR is for an initial rebrand toward being the Center for Learning, Computing, and Imagination. 

It should **not** yet be merged to main.

Before that happens we, minimally, need to secure lci.uw.edu.